### PR TITLE
Add minimal React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Project files to be delivered
 4. **Running the Example**
    - Execute `python main.py` to parse the sample lore document and generate the outputs in `examples/output/`.
 
+
+5. **Interactive HTML Demo**
+   - After generating outputs, run `python frontend/serve.py`.
+   - Open `http://localhost:8000/frontend/index.html` in your browser to play the quest using the React interface.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>QuestMaster Interactive Story</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    .choices button { margin: 5px; }
+    pre { background: #f4f4f4; padding: 10px; }
+  </style>
+</head>
+<body>
+  <div id="root">Loading...</div>
+
+  <script type="text/babel">
+    const App = () => {
+      const [data, setData] = React.useState(null);
+      const [location, setLocation] = React.useState(null);
+      const [defeated, setDefeated] = React.useState([]);
+      const [log, setLog] = React.useState([]);
+      const [narrative, setNarrative] = React.useState('');
+
+      React.useEffect(() => {
+        fetch('../examples/output/metadata.json')
+          .then(res => res.json())
+          .then(json => {
+            setData(json.quest_data);
+            setLocation(json.quest_data.initial_location);
+          });
+        fetch('../examples/output/narrative.txt')
+          .then(res => res.text())
+          .then(text => setNarrative(text));
+      }, []);
+
+      if (!data || !location) return React.createElement('div', null, 'Loading...');
+
+      const connections = data.connections
+        .filter(c => c[0] === location)
+        .map(c => c[1]);
+
+      const currentObstacle = data.obstacles[location];
+      const isObstacleDefeated = defeated.includes(currentObstacle);
+
+      const goalReached = data.goal_conditions.every(cond => {
+        if (cond.startsWith('at ')) {
+          const target = cond.split(' ')[2];
+          return location === target;
+        }
+        if (cond.startsWith('defeated ')) {
+          const obs = cond.split(' ')[1];
+          return defeated.includes(obs);
+        }
+        return false;
+      });
+
+      const moveTo = dest => {
+        setLocation(dest);
+        setLog(log.concat(`Moved to ${dest}`));
+      };
+
+      const defeat = obs => {
+        if (!defeated.includes(obs)) {
+          setDefeated(defeated.concat(obs));
+          setLog(log.concat(`Defeated ${obs}`));
+        }
+      };
+
+      return (
+        <div>
+          <h1>QuestMaster Interactive Story</h1>
+          <pre>{narrative}</pre>
+          <h2>Current location: {location}</h2>
+          {goalReached ? (
+            <h3>Quest Completed!</h3>
+          ) : (
+            <div className="choices">
+              {currentObstacle && !isObstacleDefeated && (
+                <button onClick={() => defeat(currentObstacle)}>
+                  Defeat {currentObstacle}
+                </button>
+              )}
+              {connections.map(dest => (
+                <button key={dest} onClick={() => moveTo(dest)}>
+                  Go to {dest}
+                </button>
+              ))}
+            </div>
+          )}
+          {log.length > 0 && (
+            <div>
+              <h3>Actions:</h3>
+              <ul>
+                {log.map((l, idx) => <li key={idx}>{l}</li>)}
+              </ul>
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/frontend/serve.py
+++ b/frontend/serve.py
@@ -1,0 +1,22 @@
+import http.server
+import socketserver
+from pathlib import Path
+
+PORT = 8000
+
+# Serve files relative to repository root
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def translate_path(self, path: str) -> str:
+        # Serve metadata and narrative from examples/output
+        if path.startswith('/examples/output'):
+            return str(ROOT / path.lstrip('/'))
+        # Otherwise serve from frontend directory
+        return str(HERE / path.lstrip('/'))
+
+if __name__ == '__main__':
+    with socketserver.TCPServer(('', PORT), Handler) as httpd:
+        print(f"Serving on http://localhost:{PORT}")
+        httpd.serve_forever()


### PR DESCRIPTION
## Summary
- add empty `quest_master/__init__.py` so imports work as a package
- create a lightweight React interface served from `frontend/index.html`
- provide a small Python script for serving the demo
- document how to launch the interactive HTML demo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68810fdf6420832fb7742aff44582eb4